### PR TITLE
BSR-14831 smb2.lease.request fails if directory leasing not supported

### DIFF
--- a/source4/torture/smb2/lease.c
+++ b/source4/torture/smb2/lease.c
@@ -166,7 +166,7 @@ static bool test_lease_request(struct torture_context *tctx,
 	}
 
 	/* Also rejects multiple files leased under the same key. */
-	smb2_lease_create(&io, &ls, true, fname2, LEASE1, smb2_util_lease_state("RHW"));
+	smb2_lease_create(&io, &ls, false, fname2, LEASE1, smb2_util_lease_state("RHW"));
 	status = smb2_create(tree, mem_ctx, &io);
 	CHECK_STATUS(status, NT_STATUS_INVALID_PARAMETER);
 


### PR DESCRIPTION
Creating a directory to test lease conflict behavior does not work unless directory leases are supported.  Create a file instead so the conflict behavior can be verified without directory leases.

## Samba is moving to GitLab
The samba project is moving to GitLab, please consider opening a merge request there instead.
Instructions for setting up can be found at: https://wiki.samba.org/index.php/Samba_CI_on_gitlab
The GitLab repository can be found here: https://gitlab.com/samba-team/samba
